### PR TITLE
Tests that explore jtow's bias subtraction options

### DIFF
--- a/jtow/jtow.py
+++ b/jtow/jtow.py
@@ -82,7 +82,7 @@ def log_output(TargetName):
     with open(pwd+'/stpipe-log.cfg'.format(TargetName), 'w') as conf:
         config_object.write(conf)
         
-    print("A configuration file {}_stpipe-log.cfg and a log output file {}_pipeline.log for the JWST Pipeline will be created in the working directory".format(TargetName, TargetName))
+    print("A configuration file stpipe-log.cfg and a log output file {}_pipeline.log for the JWST Pipeline will be created in the working directory".format(TargetName, TargetName))
 
 class jw(object):
     def __init__(self,paramFile=defaultParamPath,directParam=None):

--- a/tests/jtow_nrca1_custBias_None.py
+++ b/tests/jtow_nrca1_custBias_None.py
@@ -1,0 +1,80 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00001_nrca1_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca1_custBias_None/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+    
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_None/jtow_nrca1_custBias_None_params.yaml' #File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca1_custBias_None/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': None,
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca1_custBias_None/jtow_nrca1_custBias_None_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca1_custBias_None/jtow_nrca1_custBias_None_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca1_custBias_cycleBias.py
+++ b/tests/jtow_nrca1_custBias_cycleBias.py
@@ -1,0 +1,88 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+from astropy.io import fits
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00001_nrca1_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+    
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+    
+#Make a bias file
+
+bias0 = cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_subgrism256_test_bias0.fits'
+bias1 = cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_subgrism256_test_bias1.fits'
+
+if (os.path.exists(bias0) == False and os.path.exists(bias1) == False):
+    HDUList = fits.open(rawdata_file)
+    
+    image2D = HDUList[1].data[0][0] #Acting as Bias File
+    
+    bias0 = fits.writeto(cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_subgrism256_test_bias0.fits', image2D)
+    bias1 = fits.writeto(cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_subgrism256_test_bias1.fits', image2D)
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_custBias_cycleBias_params.yaml'#File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'cycleBias',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle': ['0','1','1','1'],
+                   'biasCycleSearch': cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_subgrism256_test_bias?.fits'}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_custBias_cycleBias_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca1_custBias_cycleBias/jtow_nrca1_custBias_cycleBias_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca1_custBias_lineIntercept.py
+++ b/tests/jtow_nrca1_custBias_lineIntercept.py
@@ -1,0 +1,80 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00001_nrca1_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/jtow_nrca1_custBias_lineIntercept_params.yaml'#File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'lineIntercept',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/jtow_nrca1_custBias_lineIntercept_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/jtow_nrca1_custBias_lineIntercept_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca1_custBias_selfBias.py
+++ b/tests/jtow_nrca1_custBias_selfBias.py
@@ -1,0 +1,81 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00001_nrca1_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca1_custBias_selfBias/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_selfBias/jtow_nrca1_custBias_selfBias_params.yaml' #File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca1_custBias_selfBias/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'selfBias',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca1_custBias_selfBias/jtow_nrca1_custBias_selfBias_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca1_custBias_selfBias/jtow_nrca1_custBias_selfBias_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca5_custBias_None.py
+++ b/tests/jtow_nrca5_custBias_None.py
@@ -40,7 +40,7 @@ if (os.path.exists(rawdata_file) == False):
 #HDUList = fits.open(file)
 
 #image2D = HDUList[1].data[0][0] #Acting as Bias File
-jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_None/jtow_nrca1_custBias_None_params.yaml' #File for the param file 
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca5_custBias_None/jtow_nrca5_custBias_None_params.yaml' #File for the param file 
 if (os.path.exists(jtow_Params_file) == False):
     jtow_Params = {'rawFileSearch': rawdata_file,
                    'outputDir': cwd+'/jtow_test_results/jtow_nrca5_custBias_None/',

--- a/tests/jtow_nrca5_custBias_None.py
+++ b/tests/jtow_nrca5_custBias_None.py
@@ -1,0 +1,79 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00002_nrca5_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca5_custBias_None/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_None/jtow_nrca1_custBias_None_params.yaml' #File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca5_custBias_None/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': None,
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca5_custBias_None/jtow_nrca5_custBias_None_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca5_custBias_None/jtow_nrca5_custBias_None_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca5_custBias_cycleBias.py
+++ b/tests/jtow_nrca5_custBias_cycleBias.py
@@ -1,0 +1,87 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+from astropy.io import fits
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00002_nrca5_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+    
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+    
+#Make a bias file
+bias0 = cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_subgrism256_test_bias0.fits'
+bias1 = cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_subgrism256_test_bias1.fits'
+
+if (os.path.exists(bias0) == False and os.path.exists(bias1) == False):
+    HDUList = fits.open(rawdata_file)
+
+    image2D = HDUList[1].data[0][0] #Acting as Bias File
+
+    bias0 = fits.writeto(cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_subgrism256_test_bias0.fits', image2D)
+    bias1 = fits.writeto(cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_subgrism256_test_bias1.fits', image2D)
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_custBias_cycleBias_params.yaml' #File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'cycleBias',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle': ['0','1','1','1'],
+                   'biasCycleSearch': cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_subgrism256_test_bias?.fits'}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_custBias_cycleBias_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca5_custBias_cycleBias/jtow_nrca5_custBias_cycleBias_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca5_custBias_lineIntercept.py
+++ b/tests/jtow_nrca5_custBias_lineIntercept.py
@@ -1,0 +1,80 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00002_nrca5_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca5_custBias_lineIntercept/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca1_custBias_lineIntercept/jtow_nrca5_custBias_lineIntercept_params.yaml'#File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca5_custBias_lineIntercept/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'lineIntercept',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca5_custBias_lineIntercept/jtow_nrca5_custBias_lineIntercept_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca5_custBias_lineIntercept/jtow_nrca5_custBias_lineIntercept_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()

--- a/tests/jtow_nrca5_custBias_selfBias.py
+++ b/tests/jtow_nrca5_custBias_selfBias.py
@@ -1,0 +1,79 @@
+#Download the super short GRISM256 data and its supporting SuperBias Files.
+
+#Import Library
+
+#For Zenodo downloading
+import urllib.request
+import shutil
+
+#General
+import os
+import yaml
+import glob
+
+#unittest
+import unittest
+from jtow import jtow
+
+#Get the raw uncalibrated data for NIRCam short-wavelength detector
+
+rawdata_filename_ext = 'jw88888001001_01101_00002_nrca5_uncal.fits' #raw data Name
+
+cwd = os.getcwd() #Get the current working directory 
+data_dir = cwd+'/jtow_test_results/jtow_nrca5_custBias_selfBias/Raw_Data/' #Output directroy for download data
+
+#Make a directory to store the test data
+if (os.path.exists(data_dir) == False):
+    os.makedirs(data_dir)
+
+rawdata_file = data_dir+rawdata_filename_ext #File for the raw data 
+if (os.path.exists(rawdata_file) == False):
+    raw_data = urllib.request.urlopen('https://zenodo.org/record/6688451/files/{}'.format(rawdata_filename_ext)) #Zenodo link
+    
+    with open('{}'.format(rawdata_filename_ext),'wb') as rawdata_out:
+         rawdata_out.write(raw_data.read())
+            
+    shutil.move(str(rawdata_filename_ext), str(data_dir + '/' + rawdata_filename_ext)) #Save the raw data 
+    
+#Make a bias file
+#uncalfile = data_dir+rawdata_filename_ext
+#HDUList = fits.open(file)
+
+#image2D = HDUList[1].data[0][0] #Acting as Bias File
+jtow_Params_file = cwd+'/jtow_test_results/jtow_nrca5_custBias_selfBias/jtow_nrca5_custBias_selfBias_params.yaml' #File for the param file 
+if (os.path.exists(jtow_Params_file) == False):
+    jtow_Params = {'rawFileSearch': rawdata_file,
+                   'outputDir': cwd+'/jtow_test_results/jtow_nrca5_custBias_selfBias/',
+                   'photParam': None,
+                   'noutputs': None,
+                   'add_noutputs_keyword': False, 
+                   'ROEBACorrection': True,
+                   'autoROEBAmasks': True,
+                   'maxCores': 'quarter',
+                   'ROEBAmaskfromRate': None,
+                   'ROEBAmaskfromRateThreshold': 0.5,
+                   'custBias': 'selfBias',
+                   'saveBiasStep': False,
+                   'saveROEBAdiagnostics': False,
+                   'jumpRejectionThreshold': 15.0,
+                   'ROEBAmaskGrowthSize': None,
+                   'saveJumpStep': False,
+                   'biasCycle':  None,
+                   'biasCycleSearch': None}
+                
+    #Write the test parameter file
+    with open(cwd+'/jtow_test_results/jtow_nrca5_custBias_selfBias/jtow_nrca5_custBias_selfBias_params.yaml', 'w') as file:
+        paramfile = yaml.dump(jtow_Params, file)
+    
+#Test jtow
+class Test_JTOW(unittest.TestCase):
+   
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        
+        self.examParamPath = cwd+'/jtow_test_results/jtow_nrca5_custBias_selfBias/jtow_nrca5_custBias_selfBias_params.yaml' #Path to YAML file
+       
+        self.jtow_obj = jtow.jw(paramFile = self.examParamPath) #Assign YAML file to JTOW object
+    
+    def test_run_jw(self):
+        self.jtow_obj.run_jw()


### PR DESCRIPTION
Added quick tests exploring the following bias subtraction methods: None, selfBias, lineIntercept, cycleBias. To run these tests in terminal, go to the directory '.../jtow/tests/' and then run pytest somefile.py